### PR TITLE
CDAP-13152 Handle null input schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>co.cask</groupId>
   <artifactId>dynamic-partitioner</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
   <packaging>jar</packaging>
 
   <name>Dynamic Partitioner</name>
@@ -316,7 +316,7 @@
       <plugin>
         <groupId>co.cask</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.0</version>
         <configuration>
           <cdapArtifacts>
             <parent>${data.pipeline.parent}</parent>

--- a/src/main/java/co/cask/hydrator/plugin/PartitionedFileSetSinkConfig.java
+++ b/src/main/java/co/cask/hydrator/plugin/PartitionedFileSetSinkConfig.java
@@ -118,21 +118,22 @@ public class PartitionedFileSetSinkConfig extends PluginConfig {
     return new AbstractMap.SimpleEntry<>(outputSchema, outputHiveSchema);
   }
 
-  protected Partitioning getPartitioningWithoutMacro(Schema inputSchema) {
+  protected Partitioning getPartitioningWithoutMacro(@Nullable Schema inputSchema) {
     Partitioning.Builder partitionBuilder = Partitioning.builder();
     String[] partitionFields = this.fieldNames.split(",");
     for (int i = 0; i < partitionFields.length; i++) {
-      if (inputSchema.getField(partitionFields[i]) == null) {
-        // throw exception if the field used to partition is not present in the input schema
-        throw new IllegalArgumentException(String.format("Field %s is not present in the input schema.",
-                                                         partitionFields[i]));
-      } else if (inputSchema.getField(partitionFields[i]).getSchema().isNullable()) {
-        // throw exception if input field is nullable
-        throw new IllegalArgumentException(String.format("Input field %s has to be non-nullable.",
-                                                         partitionFields[i]));
-      } else {
-        partitionBuilder.addStringField(partitionFields[i]);
+      if (inputSchema != null) {
+        if (inputSchema.getField(partitionFields[i]) == null) {
+          // throw exception if the field used to partition is not present in the input schema
+          throw new IllegalArgumentException(String.format("Field %s is not present in the input schema.",
+                                             partitionFields[i]));
+        } else if (inputSchema.getField(partitionFields[i]).getSchema().isNullable()) {
+          // throw exception if input field is nullable
+          throw new IllegalArgumentException(String.format("Input field %s has to be non-nullable.",
+                                             partitionFields[i]));
+        }
       }
+      partitionBuilder.addStringField(partitionFields[i]);
     }
     return partitionBuilder.build();
   }
@@ -140,7 +141,10 @@ public class PartitionedFileSetSinkConfig extends PluginConfig {
   /**
    * Validate plugin configuration at deployment stage.
    */
-  protected void validate(Schema inputSchema) {
+  protected void validate(@Nullable Schema inputSchema) {
+    if (inputSchema == null) {
+      return;
+    }
     // No need to validate partition fields if it is macro enabled. No need to validate output schema if
     // partition fields or output schema is macro enabled.
     if (!this.containsMacro("fieldNames")) {


### PR DESCRIPTION
[CDAP-13152](https://issues.cask.co/browse/CDAP-13152)

See the JIRA for the stack trace / error that is encountered when input schema for the plugin is not configured.
The [getInputSchema](https://github.com/caskdata/cdap/blob/release/4.3/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageContext.java#L123) method return type is `@Nullable`, so we need to be able to handle it.